### PR TITLE
chore: add docker img release workflow

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,0 +1,33 @@
+name: Release Docker image
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: "Branch or tag to release"
+        required: true
+
+permissions:
+  id-token: write # Required for requesting AWS JWT
+  contents: read # Required for actions/checkout and push commit
+
+jobs:
+  publish:
+    name: Release Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.release_ref || '' }}
+
+      - name: Move docker files to root
+        run: mv docker/Dockerfile ./
+
+      - name: Release Docker image
+        uses: Backend-RA2-Tech/composite-workflows/lerna-template/docker-build-publish@main
+        with:
+          working-directory: ./
+          force-target-repository: "usdn-backend"


### PR DESCRIPTION
The goal of this PR is to test and potentially migrate the Docker release workflow of [USDN contracts](https://github.com/SmarDex-Ecosystem/usdn-contracts) repo to this repository in order to deploy the router as well as the contract which are currently into the anvil container of [usdn-backend](https://github.com/Backend-RA2-Tech/usdn-backend/blob/ae2a819e0d0919a33587561c9ae0a5c51771608d/docker-compose.dev.yml#L18).

Additionnal note: The script called by the backend to setup the anvil container is always `./script/deployFork.sh` and this path is shared by both [usdn](https://github.com/SmarDex-Ecosystem/usdn-contracts/blob/main/script/deployFork.sh) and [router](https://github.com/SmarDex-Ecosystem/universal-router/blob/main/script/deployFork.sh) repositories. But the one of the router repo calls the one of usdn-contracts repo.