### PR TITLE
chore: update cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["dependencies/@smardex-usdn-contracts-0.20.0/test_utils"]
+members = ["dependencies/@smardex-usdn-contracts-latest/test_utils"]
 resolver = "2"


### PR DESCRIPTION
This PR aims to fix the `cargo.toml` version dependency version