### PR TITLE
test: fix bad import

### DIFF
--- a/test/units/fuzzing/_MapSafe.fuzzing.t.sol
+++ b/test/units/fuzzing/_MapSafe.fuzzing.t.sol
@@ -3,8 +3,7 @@ pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
 
-import { LockAndMapHandler } from "./utils/LockAndMapHandler.sol";
-import { LockAndMap } from "../../../../src/modules/usdn/LockAndMap.sol";
+import { LockAndMapHandler, LockAndMap } from "./utils/LockAndMapHandler.sol";
 
 /**
  * @custom:feature Test fuzzing of the {_mapSafe} function


### PR DESCRIPTION
There was always a warning when compiling the project because of a bad import