### PR TITLE
refactor: wrap eth amount name

### DIFF
--- a/src/base/Dispatcher.sol
+++ b/src/base/Dispatcher.sol
@@ -212,12 +212,12 @@ abstract contract Dispatcher is
                         } else if (command == Commands.WRAP_ETH) {
                             // equivalent: abi.decode(inputs, (address, uint256))
                             address recipient;
-                            uint256 amountMin;
+                            uint256 amount;
                             assembly {
                                 recipient := calldataload(inputs.offset)
-                                amountMin := calldataload(add(inputs.offset, 0x20))
+                                amount := calldataload(add(inputs.offset, 0x20))
                             }
-                            Payments.wrapETH(map(recipient), amountMin);
+                            Payments.wrapETH(map(recipient), amount);
                         } else if (command == Commands.UNWRAP_WETH) {
                             // equivalent: abi.decode(inputs, (address, uint256))
                             address recipient;


### PR DESCRIPTION
This PR aims to refactor the `amountMin` to `amount` parameter of the `WRAP_ETH` comment to improve clarity.

Closes RA2BL-379